### PR TITLE
Fix OpenCV dependency for Windows imports

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Core runtime
 PySide6==6.7.2
-opencv-python-headless==4.10.0.84
+opencv-python==4.10.0.84
 onnxruntime==1.19.2
 fastapi==0.115.0
 uvicorn[standard]==0.30.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core runtime
 PySide6==6.7.2
-opencv-python-headless==4.10.0.84
+opencv-python==4.10.0.84
 onnxruntime==1.19.2
 fastapi==0.115.0
 uvicorn[standard]==0.30.6


### PR DESCRIPTION
## Summary
- switch dependency to `opencv-python` so `cv2` is installed in Windows environments
- update pinned requirements files to align with the new OpenCV package

## Testing
- not run (dependency-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693baa15bbf48332b5c704c188919a89)