### PR TITLE
Auto-start installer after system checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ tests/             # Pytest-yksikkötestit
 ### Automaattinen asennus (suositeltu)
 Käytä reaktiivista asennusohjelmaa, joka asentaa kaikki riippuvuudet, testaa asennuksen ja korjaa automaattisesti virheet:
 
+> GUI käynnistää asennuksen automaattisesti heti kun järjestelmätarkistus valmistuu – erillistä "Start"-painallusta ei tarvita.
+
 **Windows:**
 ```batch
 install_dependencies.bat

--- a/install.py
+++ b/install.py
@@ -10,6 +10,7 @@ This script provides a graphical installation experience that:
 
 Falls back to CLI mode if GUI is not available.
 """
+# Ship intelligence, not excuses.
 
 import subprocess
 import sys
@@ -35,6 +36,7 @@ class InstallerGUI:
         
         # State variables
         self.installation_complete = False
+        self.installation_started = False
         self.python_version_ok = False
         self.dependencies_installed = False
         self.app_tested = False
@@ -240,17 +242,29 @@ class InstallerGUI:
                 self.progress_label.config(text="System check complete - Ready to install")
                 self.install_button.config(state=tk.NORMAL)
                 self.log("\n✓ System check complete. Click 'Start Installation' to continue.")
-                
+                self.root.after(300, self.auto_start_installation)
+
             except Exception as e:
                 self.progress_bar.stop()
                 self.log(f"\n✗ Error during system check: {e}")
                 self.update_status('python', "✗ Fail", "red")
                 messagebox.showerror("System Check Failed", str(e))
-        
+
         threading.Thread(target=check, daemon=True).start()
-    
+
+    def auto_start_installation(self):
+        """Start installation automatically after checks."""
+        if self.installation_started or not self.python_version_ok:
+            return
+        self.log("\nAuto-starting installation to complete setup without extra clicks.")
+        self.start_installation()
+
     def start_installation(self):
         """Start the installation process"""
+        if self.installation_started:
+            self.log("Installation already running.")
+            return
+        self.installation_started = True
         self.install_button.config(state=tk.DISABLED)
         self.progress_bar.start()
         


### PR DESCRIPTION
## Summary
- auto-start the GUI installer as soon as system checks pass while guarding against duplicate runs
- log the automatic start and keep the launch/start controls while preventing re-entry
- document the hands-off install flow in the README for clarity

## Testing
- python -m pytest tests/test_humanize.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b67f7bcb88332bf05353d74701f11)